### PR TITLE
add BGA and CSP as packages, minor fixes in help

### DIFF
--- a/bom/constants.py
+++ b/bom/constants.py
@@ -92,6 +92,8 @@ PACKAGE_TYPES = (
     ('QFT', 'QFT'),
     ('PLCC', 'PLCC'),
     ('VGA', 'VGA'),
+    ('BGA', 'BGA'),
+    ('CSP', 'CSP'),
     ('Other', 'Other'),
 )
 

--- a/bom/templates/bom/help.html
+++ b/bom/templates/bom/help.html
@@ -1078,7 +1078,7 @@
                     <p>Value Units = Ohms, mOhms, kOhms, MOhms, F, pF, nF, uF, V, uV, mV, A, uA, mA, C, F, H, nH, mH, uH, Other</p>
                     <p>Package Type = 0201 smd, 0402 smd, 0603 smd, 0805 smd, 1206 smd, 1210 smd, 1812 smd, <br/>2010 smd, 2512 smd, 1/8 radial, 1/4 radial, 1/2 radial, Size A, Size B, Size C, Size D,
                         Size E,
-                        SOT-23, <br/>SOT-223, DIL, SOP, SOIC, QFN, QFP, QFT, PLCC, VGA&nbsp;</p>
+                        SOT-23, <br/>SOT-223, DIL, SOP, SOIC, QFN, QFP, QFT, PLCC, VGA, BGA, CSP </p>
                     <p>Power Units = W, uW, mW, kW, MW</p>
                     <p>Voltage Units = V, uV, mV, kV, MV</p>
                     <p>Current Units = A, uA, mA, kA, MA</p>
@@ -1086,7 +1086,7 @@
                     <p>Memory Units = KB, MB, GB, TB</p>
                     <p>Interface Types = I2C, SPI, CAN, One-Wire, RS485, RS232, WiFi, 4G, BT, Z_Wave, Zigbee, LAN, USB, HDMI, Other</p>
                     <p>Frequency Units = Hz, kHz MHz, GHz</p>
-                    <p>Wavelength Units = km m, cm, um, nm, A (where A means &Aring;ngstrom)</p>
+                    <p>Wavelength Units = km, m, cm, um, nm, A (where A means &Aring;ngstrom)</p>
                     <p>Distance Units = mil, in, ft, yd, km, m, cm, um, nm</p>
                     <p>Weight Units = mg, g, kb, oz, lb</p>
                 </div>

--- a/bom/templates/bom/upload-parts-help.html
+++ b/bom/templates/bom/upload-parts-help.html
@@ -76,7 +76,7 @@
         <p/>
         <p><b>'package'</b> = 0201 smd, 0402 smd, 0603 smd, 0805 smd, 1206 smd, 1210 smd, 1812 smd,
             2010 smd, 2512 smd, 1/8 radial, 1/4 radial, 1/2 radial, Size A, Size B, Size C, Size D, Size E, SOT-23,
-            SOT-223, DIL, SOP, SOIC, QFN, QFP, QFT, PLCCP, VGA</p>
+            SOT-223, DIL, SOP, SOIC, QFN, QFP, QFT, PLCCP, VGA, BGA, CSP</p>
         <p><b>'power_rating'</b> = W, uW, mW, kW, MW</p>
         <p><b>'supply_voltage'</b>, <b>'voltage_rating'</b> = V, uV, mV, kV, MV</p>
         <p><b>'current_rating'</b> = A, uA, mA, kA, MA</p>
@@ -84,7 +84,7 @@
         <p><b>'memory'</b> = KB, MB, GB, TB</p>
         <p><b>'interface'</b> = I2C, SPI, CAN, One-Wire, RS485, RS232, WiFi, 4G, BT, Z_Wave, Zigbee, LAN, USB, HDMI, Other</p>
         <p><b>'frequency'</b> = Hz, kHz MHz, GHz</p>
-        <p><b>'wavelength'</b> = km m, cm, um, nm, A (where A means Angstrom)</p>
+        <p><b>'wavelength'</b> = km, m, cm, um, nm, A (where A means Angstrom)</p>
         <p><b>'length'</b>, <b>'width'</b>, <b>'height'</b> = mil, in, ft, yd, km, m, cm, um, nm</p>
         <p><b>'weight'</b> = mg, g, kb, oz, lb</p>
         </p>


### PR DESCRIPTION
This PR adds two new package types: `BGA` (ball grid array) and `CSP` (chip scaled package).

It also fixes a missing colon in the help.